### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def imageName = 'jenkinsciinfra/l10n-server'
 properties([[$class: 'BuildDiscarderProperty',
                 strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
 
-node('docker') {
+node('docker&&linux') {
     checkout scm
 
     /* Using this hack right now to grab the appropriate abbreviated SHA1 of


### PR DESCRIPTION
When Windows docker agents are available, make sure we only run this on Linux docker agents.